### PR TITLE
Add documentation for symfony 2.0 installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,50 @@ and add the repositories:
         new Liuggio\ExcelBundle\LiuggioExcelBundle(),
     );
 ```
+
+## INSTALLATION with deps file
+
+1  Add to the following to your `deps` file, then run `php bin/vendors install`
+
+``` yaml
+[PHPExcel]
+    git=http://github.com/PHPOffice/PHPExcel.git
+    target=/phpexcel
+    version=origin/master
+
+[n3bStreamresponse]
+    git=git://github.com/liuggio/Symfony2-StreamResponse.git
+    target=n3b/src/n3b/Bundle/Util/HttpFoundation/StreamResponse
+
+[LiuggioExcelBundle]
+    git=https://github.com/liuggio/ExcelBundle.git
+    target=/bundles/Liuggio/ExcelBundle
+``` 
+
+2  Register the namespaces and prefixes in `app/autoload.php`:
+
+``` php
+    $loader->registerNamespaces(array(
+        // ...
+        'n3b\\Bundle\\Util\\HttpFoundation\\StreamResponse' => __DIR__.'/../vendor/n3b/src',
+        'Liuggio'          => __DIR__.'/../vendor/bundles',
+    ));
+    $loader->registerPrefixes(array(
+        // ...
+        'PHPExcel'         => __DIR__.'/../vendor/phpexcel/Classes',
+    ));
+
+```
+ 
+
+3 Enable the bundle in `app/AppKernel.php`
+
+``` php
+    $bundles = array(
+        // ...
+        new Liuggio\ExcelBundle\LiuggioExcelBundle(),
+    );
+```
  
 
 


### PR DESCRIPTION
I added documentation for how to install for symfony 2.0. The bundle currently doesn't seem to use anything that doesn't work post 2.0, so no need to branch yet.

Another thing I did was point to the official PHPExcel repository, which is constantly updated. I would have done it in the composer file as well, but I didn't want to break anything in case I did it improperly since I'm not able to test it.

You might want to clean up the file structure of the streamwriter repo. The namespace doesn't look terribly pretty in the autoloader.
