### PR TITLE
Update version of CodePlex/PHPExcel in composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.2",
         "symfony/framework-bundle": "2.*",
         "irongit/symfony2-stream-response": ">=1.0",
-        "CodePlex/PHPExcel": ">=1.7"
+        "phpoffice/phpexcel": ">=1.7"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
A dependency to PHPExcel seems a bit outdated as the version 1.7.9 is almost ready.
