### PR TITLE
Switch "CodePlex/PHPExcel" required version to 1.7.9 (last stable)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": ">=5.3.2",
         "symfony/framework-bundle": "2.*",
         "irongit/symfony2-stream-response": ">=1.0",
-        "CodePlex/PHPExcel": "1.7.8"
+        "phpoffice/phpexcel": "1.7.9"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
It's the last stable release. Plus, as mentioned on https://phpexcel.codeplex.com/ it's the last stable before 2.0.0

So I think it would be a great idea to upgrade the current required version and then watch out for 2.0.0...
