### PR TITLE
Added sendHeaders for compatibility with https connections and IE<9

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,10 @@ class DefaultController extends Controller
         $response->headers->set('Content-Type', 'text/vnd.ms-excel; charset=utf-8');
         $response->headers->set('Content-Disposition', 'attachment;filename=stdream2.xls');
         
-        // If you are using a https connection, you have to set those two headers for compatibility with IE <9
+        // If you are using a https connection, you have to set those two headers and use sendHeaders() for compatibility with IE <9
         $response->headers->set('Pragma', 'public');
         $response->headers->set('Cache-Control', 'maxage=1');
+        $response->sendHeaders();
         return $response;        
     }
 }


### PR DESCRIPTION
Added sendHeaders() fix for https and IE < 9 compatibility to the readme as discussed in #45
