### PR TITLE
Changed createPHPExcelObject to pass filename as a string to fix Context...

### DIFF
--- a/Factory.php
+++ b/Factory.php
@@ -32,7 +32,7 @@ class Factory
             return $phpExcelObject;
         }
 
-        return call_user_func(array($this->phpExcelIO, 'load'), array($filename));
+        return call_user_func(array($this->phpExcelIO, 'load'), $filename);
     }
 
     /**


### PR DESCRIPTION
...ErrorException

$phpExcelObject = $this->get('phpexcel')->createPHPExcelObject('file.xls') fails with ContextErrorException: Warning: pathinfo() expects parameter 1 to be string, array given in vendor/phpoffice/phpexcel/Classes/PHPExcel/IOFactory.php line 224 (Symfony 2.4, PHP 5.5.6).
