### PR TITLE
Update PHPExcel to 1.8.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": ">=5.3.2",
         "symfony/framework-bundle": "~2.1",
-        "phpoffice/phpexcel": "1.7.9"
+        "phpoffice/phpexcel": "~1.8.0"
     },
     "require-dev": {
         "phpunit/PHPUnit": "3.7.*",


### PR DESCRIPTION
1.8.0 is for quite a while (and it's quite substantial update), thus time for change.

Also, 1.8.0 contains breaking changes for some cases, therefore it should probably go to liuggio/ExcelBundle:2.1.0 ?
