### PR TITLE
Updated documentation with missing dispositionHeader set

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,7 @@ class DefaultController extends Controller
         $response->headers->set('Content-Type', 'text/vnd.ms-excel; charset=utf-8');
         $response->headers->set('Pragma', 'public');
         $response->headers->set('Cache-Control', 'maxage=1');
+        $response->headers->set('Content-Disposition', $dispositionHeader);
 
         return $response;        
     }


### PR DESCRIPTION
Setting the Header with Content-Disposition was missing in the documentation