### PR TITLE
Update travis.yml with PHP 7.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
+  - 7.1
 
 matrix:
   include:
@@ -20,8 +20,11 @@ matrix:
       env: SYMFONY_VERSION="2.8.*@dev symfony/phpunit-bridge:~2.7"
     - php: 5.6
       env: SYMFONY_VERSION="3.0.*@dev"
+    - php: hhvm
+      dist: trusty
   allow_failures:
     - php: 7.0
+    - php: 7.1
   fast_finishe: true
 
 before_install:


### PR DESCRIPTION
As PHP 7.1 is out since December (6 months) I think is useful to test the codebase against it.

PS.: Is `allow_failures` section correct? Could we drop it?