### PR TITLE
added create file response to factory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 bin
 vendor
 Tests/app/cache
+.idea
+composer.lock

--- a/Factory.php
+++ b/Factory.php
@@ -2,6 +2,8 @@
 
 namespace Liuggio\ExcelBundle;
 
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 use Symfony\Component\HttpFoundation\StreamedResponse;
 
 /**
@@ -85,6 +87,38 @@ class Factory
             $status,
             $headers
         );
+    }
+
+    /**
+     * Create a File Response
+     *
+     * @param \PHPExcel_Writer_IWriter $writer
+     * @param string                   $filename
+     * @param int                      $status
+     * @param array                    $headers
+     *
+     * @return BinaryFileResponse
+     */
+    public function createFileResponse(\PHPExcel_Writer_IWriter $writer, $filename, $status = 200, $headers = array())
+    {
+        $tempFilename = @tempnam(\PHPExcel_Shared_File::sys_get_temp_dir(), 'phpxlstmp');
+        $writer->save($tempFilename);
+
+        $response = new BinaryFileResponse(
+            $tempFilename,
+            $status,
+            $headers
+        );
+
+        $response->headers->set('Content-Type', 'text/vnd.ms-excel; charset=utf-8');
+        $response->headers->set('Pragma', 'public');
+        $dispositionHeader = $response->headers->makeDisposition(
+            ResponseHeaderBag::DISPOSITION_ATTACHMENT,
+            $filename
+        );
+        $response->headers->set('Content-Disposition', $dispositionHeader);
+
+        return $response;
     }
 
     /**

--- a/Tests/Controller/FakeControllerTest.php
+++ b/Tests/Controller/FakeControllerTest.php
@@ -3,6 +3,7 @@
 namespace Liuggio\ExcelBundle\Tests\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 
@@ -20,6 +21,24 @@ class FakeControllerTest extends WebTestCase
 
         $this->assertEquals(Response::HTTP_OK, $client->getResponse()->getStatusCode(), $client->getResponse()->getContent());
         $this->assertStringStartsWith('attachment;filename=', $client->getResponse()->headers->get('content-disposition'));
+
+        $this->assertNotEmpty($content, 'Response should not be empty');
+        $this->assertNotNull($content, 'Response should not be null');
+    }
+
+    public function testFileAction()
+    {
+        $client = static::createClient();
+
+        $client->request(Request::METHOD_GET, '/fake/file');
+
+        /** @var BinaryFileResponse $response */
+        $response = $client->getResponse();
+        $response->sendContent();
+        $content = ob_get_contents();
+        ob_clean();
+
+        $this->assertEquals(Response::HTTP_OK, $response->getStatusCode(), $content);
 
         $this->assertNotEmpty($content, 'Response should not be empty');
         $this->assertNotNull($content, 'Response should not be null');

--- a/Tests/FactoryTest.php
+++ b/Tests/FactoryTest.php
@@ -3,6 +3,9 @@
 namespace Liuggio\ExcelBundle\Tests;
 
 use Liuggio\ExcelBundle\Factory;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use Symfony\Component\HttpFoundation\BinaryFileResponse;
 
 class FactoryTest extends \PHPUnit_Framework_TestCase
 {
@@ -33,6 +36,23 @@ class FactoryTest extends \PHPUnit_Framework_TestCase
 
         $factory =  new Factory();
         $factory->createStreamedResponse($writer)->sendContent();
+    }
+
+    public function testCreateFileResponse()
+    {
+        $filename = 'testfilename';
+        /** @var ObjectProphecy|\PHPExcel_Writer_IWriter $writer */
+        $writer = $this->prophesize('\PHPExcel_Writer_IWriter');
+        $writer->save(Argument::type('string'))->shouldBeCalled();
+
+        $factory =  new Factory();
+        $response = $factory->createFileResponse($writer->reveal(), $filename);
+        
+        $this->assertNotEmpty($response->getFile());
+        $headers = $response->headers;
+        $this->assertStringStartsWith('text/vnd.ms-excel', $headers->get('Content-Type'));
+        $this->assertEquals('public', $headers->get('Pragma'));
+        $this->assertStringStartsWith('attachment; filename=', $headers->get('content-disposition'));
     }
 
     public function testCreateHelperHtml()

--- a/Tests/app/Controller/FakeController.php
+++ b/Tests/app/Controller/FakeController.php
@@ -4,6 +4,7 @@ namespace  Liuggio\ExcelBundle\Controller;
 
 use Symfony\Bundle\FrameworkBundle\Controller\Controller;
 use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpFoundation\ResponseHeaderBag;
 
 class FakeController extends Controller
 {
@@ -20,6 +21,21 @@ class FakeController extends Controller
         $response->headers->set('Content-Disposition', 'attachment;filename=stream-file.xls');
         $response->headers->set('Pragma', 'public');
         $response->headers->set('Cache-Control', 'maxage=1');
+
+        return $response;
+    }
+
+    public function fileAction()
+    {
+        // create an empty object
+        $phpExcelObject = $this->createXSLObject();
+
+        $phpExcelFactory = $this->get('phpexcel');
+        // create the writer
+        $writer = $phpExcelFactory->createWriter($phpExcelObject, 'Excel5');
+        $filename = 'xls-'.uniqid().'.xls';
+        // create the response
+        $response = $phpExcelFactory->createFileResponse($writer, $filename);
 
         return $response;
     }

--- a/Tests/app/routing.yml
+++ b/Tests/app/routing.yml
@@ -2,6 +2,10 @@ fake_route_stream:
     path:      /fake/stream
     defaults:  { _controller: LiuggioExcelBundle:Fake:stream }
 
+fake_route_file:
+    path:      /fake/file
+    defaults:  { _controller: LiuggioExcelBundle:Fake:file }
+
 fake_route_store:
     path:      /fake/store
     defaults:  { _controller: LiuggioExcelBundle:Fake:store }


### PR DESCRIPTION
I had problems when browser receive a stream response. After search for a solution I thought the idea of return a stream response for a file it is not the best idea. Then I create a file response using BinaryFileResponse of HttpFoundation of symfony and this is the code that I did.
